### PR TITLE
Allow iRODS usernames containing "@" signs

### DIFF
--- a/src/main/java/org/irods/jargon/webdav/resource/IrodsSecurityManager.java
+++ b/src/main/java/org/irods/jargon/webdav/resource/IrodsSecurityManager.java
@@ -71,12 +71,6 @@ public class IrodsSecurityManager implements SecurityManager {
 		log.info("authenticate()");
 		clearThreadlocals();
 
-		// user name will include domain when coming from ftp. we just strip it
-		// off
-		if (userName.contains("@")) {
-			userName = userName.substring(0, userName.indexOf("@"));
-		}
-
 		try {
 			AuthResponse authResponse = irodsAuthService.authenticate(userName,
 					password);


### PR DESCRIPTION
These lines of code were preventing us from using at-signs in our iRODS usernames. Removing them fixes this problem and doesn't seem to negatively affect any other functionality.

We mentioned this issue in https://groups.google.com/forum/#!topic/iROD-Chat/WG7XJ99cEHQ .