### PR TITLE
Fix basic auth rejecting passwords containing colons

### DIFF
--- a/src/main/java/org/irods/jargon/webdav/authfilter/WebDavAuthUtils.java
+++ b/src/main/java/org/irods/jargon/webdav/authfilter/WebDavAuthUtils.java
@@ -70,7 +70,7 @@ public class WebDavAuthUtils {
 			throw new JargonException("user and password not in credentials");
 
 		}
-		final String[] credentials = decoded.split(":");
+		final String[] credentials = decoded.split(":", 2);
 
 		log.debug("credentials:{}", credentials);
 


### PR DESCRIPTION
Hi again,
We ran into another problem where passwords containing `:` characters were being rejected by the basic auth parser. It seems that the `user:password` credentials string is being split without a limit, and the code later checks whether it's been split into two parts.
According to [RFC 2617](http://www.ietf.org/rfc/rfc2617.txt) (page 6) the password may contain colon characters, but the username may not, so splitting only on the first colon seems to be a correct solution.
Hope this helps!