### PR TITLE
Use JCS to cache authenticated IRODSAccount object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@ tmp/**/*
 *~.nib
 local.properties
 testing.properties
-
+test-irods-webdav.properties 
 .classpath
 .settings/
 .loadpath

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -3,3 +3,7 @@ README
 For notes on building with milton-ce (for WebDav1) versus milton-enterprise, see
 
 https://github.com/DICE-UNC/irods-webdav/wiki/Developer-Notes
+
+The codebase assumes that a Milton key is provided in the settings.xml file for the maven build process.  It is suggested that the drop-in .war deployment process is followed, which is desribed in the INSTALL.md file.
+
+Note that DFC and the iRODS Consortium have an OEM license to pre-build the .war file.  Configuration has been moved to an /etc/irods-ext/irods-webdav.properties file, and a sample is included in this repo source tree.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,24 @@
+# Install notes
+
+RENCI and DFC have arranged to OEM the milton 'enterprise' libraries as part of iRODS WebDav support, providing full WebDav 2
+capability, free for you to deploy and use with your iRODS grid.  Therefore, we have developed a drop-in .war file that contains
+all of the necessary compiled code and keys, and exported the configuration to /etc/irods-ext/irods-webdav.properties.
+
+Install is thus rather straight forward:
+
+* Install the release .war file on your container (e.g. Tomcat)
+
+* Copy the irods-webdav.properties to /etc/irods-ext and make it readable by the tomcat or other container service user
+
+* Configure irods-webdav.properties to your particular grid.  Note that WebDav uses a preset host/port/zone and translates the Basic Authentication credentials of the user to set the logged in account
+
+Note that WebDav needs to be at a root url (e.g. http://mywebdav.org versus http://mywebdav.org/somecontext) at port 80, or with https:// on the standard port.  If it is not thus configured, certain
+clients may not properly connect (such as Mac Finder or Windows Explorer).  
+
+See the [compatability notes](http://milton.io/guide/compat/index.html) at Milton for tips
+
+The iRODS Consortium did a nice blog post on installing and configuring that can be accessed [here](http://irods.org/2015/04/how-to-drag-and-drop-access-to-irods-with-webdav/)
+
+
+
+

--- a/README.md
+++ b/README.md
@@ -1,20 +1,33 @@
-* Project: iRODS WebDav
-* Date: 
-* Release Version: 
-* Git tag: MASTER
+# Project: iRODS WebDav
+## Date: 12/01/2015
+## Release Version: 4.0.2.5-RC1
+## Git tag: 4.0.2.5-RC1
+
+
 https://github.com/DICE-UNC/irods-webdav
 
 Milton based WebDav interface to iRODS.  This is differentiated from the ModeShape approach by providing a lightweight, no cached implementation that maps web requests directly to iRODS accounts.
 
 See https://github.com/DICE-UNC/irods-webdav/issues for support and known issues
 
+See the INSTALL.md file in this repo for notes on install and configuration.
+
+## NOTE: ##
+
+This is a release candidate, and thus has INFO level logging enabled, this will potentially generate a lot of data, and will be dialed back for release.
+
+This version does not enforce a cap on max file upload, that will be in the next release.  It does honor the max file download size.
 
 ### Requirements
 
-* Depends on Java 1.7+
+* Depends on Java 1.8+
 * Built using Apache Maven2, see POM for dependencies
-
+* Built using a Milton.io webdav enterprise version key
 
 ### Bug Fixes
 
 ### Features
+
+#### Initial release
+
+This is the initial release of iRODS WebDav support using Milton, a lightweight WebDav library.  DFC and the iRODS Consortium, in collaboration, are providing a WebDav connector that includes the Milton 'enterprise' license keys in a pre-packaged deployment supporting WebDav level 2.

--- a/etc/irods-ext/irods-webdav.properties
+++ b/etc/irods-ext/irods-webdav.properties
@@ -1,0 +1,12 @@
+irods.host=localhost
+irods.port=1247
+irods.zone=tempZone
+utilize.packing.streams=true
+auth.type=STANDARD
+default.storage.resource=
+default.starting.location=USER_HOME
+provided.starting.location.path=
+cache.file.demographics=true
+utilize.packing.streams=true
+max.upload.in.gb=5
+max.download.in.gb=700

--- a/pom.xml
+++ b/pom.xml
@@ -10,10 +10,10 @@
 	<description>Milton based WebDav interface to iRODS</description>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<jargon.version>4.0.2.3-RELEASE</jargon.version>
+		<jargon.version>4.0.2.4-RELEASE</jargon.version>
 		<maven.compiler.source>1.7</maven.compiler.source>
 		<maven.compiler.target>1.7</maven.compiler.target>
-		<milton.version>2.6.5.6</milton.version>
+		<milton.version>2.7.1.3</milton.version>
 		<spring.version>3.2.13.RELEASE</spring.version>
 		<milton.level>milton-server-ce</milton.level>
 	</properties>

--- a/pom.xml
+++ b/pom.xml
@@ -4,33 +4,20 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.irods.jargon</groupId>
 	<artifactId>irods-webdav</artifactId>
-	<version>0.0.1-SNAPSHOT</version>
+	<version>4.0.2.5-RC1</version>
 	<name>irods-webav</name>
 	<packaging>war</packaging>
 	<description>Milton based WebDav interface to iRODS</description>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<jargon.version>4.0.2.4-RELEASE</jargon.version>
+		<jargon.version>4.0.2.5-SNAPSHOT</jargon.version>
 		<maven.compiler.source>1.7</maven.compiler.source>
 		<maven.compiler.target>1.7</maven.compiler.target>
 		<milton.version>2.7.1.3</milton.version>
 		<spring.version>3.2.13.RELEASE</spring.version>
-		<milton.level>milton-server-ce</milton.level>
+		<sl4j.level>1.6.6</sl4j.level>
 	</properties>
 	<repositories>
-		<repository>
-			<id>ibiblio.repository</id>
-			<name>ibiblio.repository</name>
-			<url>http://mirrors.ibiblio.org/pub/mirrors/maven2</url>
-			<releases>
-				<enabled>true</enabled>
-			</releases>
-			<snapshots>
-				<enabled>true</enabled>
-				<updatePolicy>never</updatePolicy>
-				<checksumPolicy>fail</checksumPolicy>
-			</snapshots>
-		</repository>
 		<repository>
 			<id>ettrema-repo</id>
 			<url>http://milton.io/maven/</url>
@@ -74,15 +61,16 @@
 			<version>6.0</version>
 			<scope>provided</scope>
 		</dependency>
+		<!-- 
+		<dependency>
+			<groupId>io.milton</groupId>
+			<artifactId>milton-api</artifactId>
+			<version>${milton.version}</version>
+		</dependency>  -->
 		<dependency>
 			<groupId>io.milton</groupId>
 			<artifactId>${milton.level}</artifactId>
 			<version>${milton.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-log4j12</artifactId>
-			<version>1.6.1</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>
@@ -107,12 +95,12 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>1.6.6</version>
+			<version>${sl4j.level}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-log4j12</artifactId>
-			<version>1.6.6</version>
+			<version>${sl4j.level}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>
@@ -249,7 +237,7 @@
 							<goal>run</goal>
 						</goals>
 					</execution>
-						<execution>
+					<execution>
 						<id>milton-copy</id>
 						<phase>validate</phase>
 						<configuration>
@@ -257,11 +245,43 @@
 								<property name="resource.dir" value="${project.basedir}/src/main/resources" />
 								<delete file="${resource.dir}/milton.license.sig" />
 								<delete file="${resource.dir}/milton.license.properties" />
-									<echo message="copy milton license data to resources" />
-									<copy file="${milton.source.path}/milton.license.sig"
-										tofile="${resource.dir}/milton.license.sig" />
-									<copy file="${milton.source.path}/milton.license.properties"
-										tofile="${resource.dir}/milton.license.properties" />
+								<echo message="copy milton license data to resources" />
+								<copy file="${milton.source.path}/milton.license.sig"
+									tofile="${resource.dir}/milton.license.sig" />
+								<copy file="${milton.source.path}/milton.license.properties"
+									tofile="${resource.dir}/milton.license.properties" />
+							</tasks>
+						</configuration>
+						<goals>
+							<goal>run</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>test-webdav-props</id>
+						<phase>validate</phase>
+						<configuration>
+							<tasks>
+								<delete
+									file="${basedir}/src/test/resources/test-irods-webdav.properties" />
+								<touch
+									file="${basedir}/src/test/resources/test-irods-webdav.properties"
+									mkdirs="true" />
+								<echo
+									file="${basedir}/src/test/resources/test-irods-webdav.properties"
+									append="true">
+									irods.host=${jargon.test.irods.host}
+									irods.port=${jargon.test.irods.port}
+									irods.zone=${jargon.test.irods.zone}
+									utilize.packing.streams=true
+									auth.type=STANDARD
+									default.storage.resource=
+									default.starting.location=USER_HOME
+									provided.starting.location.path=
+									cache.file.demographics=true
+									utilize.packing.streams=true
+									max.upload.in.gb=6
+									max.download.in.gb=700
+								</echo>
 							</tasks>
 						</configuration>
 						<goals>
@@ -287,41 +307,39 @@
 					<warName>irods-webdav</warName>
 				</configuration>
 			</plugin>
-			
+
 		</plugins>
 		<pluginManagement>
 			<plugins>
-				<!--This plugin's configuration is used to store Eclipse m2e settings 
-					only. It has no influence on the Maven build itself. -->
+
+			<!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
 				<plugin>
-					<groupId>org.eclipse.m2e</groupId>
-					<artifactId>lifecycle-mapping</artifactId>
-					<version>1.0.0</version>
-					<configuration>
-						<lifecycleMappingMetadata>
-							<pluginExecutions>
-								<pluginExecution>
-									<pluginExecutionFilter>
-										<groupId>
-											org.apache.maven.plugins
-										</groupId>
-										<artifactId>
-											maven-antrun-plugin
-										</artifactId>
-										<versionRange>
-											[1.3,)
-										</versionRange>
-										<goals>
-											<goal>run</goal>
-										</goals>
-									</pluginExecutionFilter>
-									<action>
-										<ignore />
-									</action>
-								</pluginExecution>
-							</pluginExecutions>
-						</lifecycleMappingMetadata>
-					</configuration>
+				<groupId>org.eclipse.m2e</groupId>
+				<artifactId>lifecycle-mapping</artifactId>
+				<version>1.0.0</version>
+				<configuration>
+					<lifecycleMappingMetadata>
+						<pluginExecutions>
+							<pluginExecution>
+								<pluginExecutionFilter>
+									<groupId>
+										org.apache.maven.plugins
+									</groupId>
+									<artifactId>
+										maven-antrun-plugin
+									</artifactId>
+									<versionRange>[1.3,)</versionRange>
+									<goals>
+										<goal>run</goal>
+									</goals>
+								</pluginExecutionFilter>
+								<action>
+									<ignore></ignore>
+								</action>
+							</pluginExecution>
+						</pluginExecutions>
+					</lifecycleMappingMetadata>
+				</configuration>
 				</plugin>
 			</plugins>
 		</pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -10,10 +10,10 @@
 	<description>Milton based WebDav interface to iRODS</description>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<jargon.version>4.0.2.3-RC1</jargon.version>
+		<jargon.version>4.0.2.3-RELEASE</jargon.version>
 		<maven.compiler.source>1.7</maven.compiler.source>
 		<maven.compiler.target>1.7</maven.compiler.target>
-		<milton.version>2.6.5.3</milton.version>
+		<milton.version>2.6.5.6</milton.version>
 		<spring.version>3.2.13.RELEASE</spring.version>
 		<milton.level>milton-server-ce</milton.level>
 	</properties>
@@ -144,6 +144,11 @@
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-web</artifactId>
 			<version>${spring.version}</version>
+		</dependency>
+		<dependency>
+		    <groupId>org.apache.commons</groupId>
+		    <artifactId>commons-jcs-core</artifactId>
+		    <version>2.0-beta-1</version>
 		</dependency>
 	</dependencies>
 

--- a/sample-maven-settings.xml
+++ b/sample-maven-settings.xml
@@ -12,6 +12,7 @@
 			<properties>
 				<milton.level>milton-server-ce</milton.level>
 			</properties>
+			
 		</profile>
 		<profile>
 			<id>irodsWebdavEnterprise</id>
@@ -20,6 +21,8 @@
 				<milton.source.path>/home/test/milton</milton.source.path>
 				<milton.copy.license>true</milton.copy.license>
 			</properties>
+			
+
 		</profile>
 
 	</profiles>

--- a/src/main/java/org/irods/jargon/webdav/authfilter/AuthWrapper.java
+++ b/src/main/java/org/irods/jargon/webdav/authfilter/AuthWrapper.java
@@ -26,7 +26,7 @@ public class AuthWrapper implements DiscretePrincipal {
 
 	/*
 	 * (non-Javadoc)
-	 *
+	 * 
 	 * @see io.milton.principal.Principal#getIdenitifer()
 	 */
 	@Override
@@ -37,7 +37,7 @@ public class AuthWrapper implements DiscretePrincipal {
 
 	/*
 	 * (non-Javadoc)
-	 *
+	 * 
 	 * @see io.milton.resource.Resource#authenticate(java.lang.String,
 	 * java.lang.String)
 	 */
@@ -48,7 +48,7 @@ public class AuthWrapper implements DiscretePrincipal {
 
 	/*
 	 * (non-Javadoc)
-	 *
+	 * 
 	 * @see io.milton.resource.Resource#authorise(io.milton.http.Request,
 	 * io.milton.http.Request.Method, io.milton.http.Auth)
 	 */
@@ -60,7 +60,7 @@ public class AuthWrapper implements DiscretePrincipal {
 
 	/*
 	 * (non-Javadoc)
-	 *
+	 * 
 	 * @see io.milton.resource.Resource#checkRedirect(io.milton.http.Request)
 	 */
 	@Override
@@ -71,7 +71,7 @@ public class AuthWrapper implements DiscretePrincipal {
 
 	/*
 	 * (non-Javadoc)
-	 *
+	 * 
 	 * @see io.milton.resource.Resource#getModifiedDate()
 	 */
 	@Override
@@ -81,7 +81,7 @@ public class AuthWrapper implements DiscretePrincipal {
 
 	/*
 	 * (non-Javadoc)
-	 *
+	 * 
 	 * @see io.milton.resource.Resource#getName()
 	 */
 	@Override
@@ -91,7 +91,7 @@ public class AuthWrapper implements DiscretePrincipal {
 
 	/*
 	 * (non-Javadoc)
-	 *
+	 * 
 	 * @see io.milton.resource.Resource#getRealm()
 	 */
 	@Override
@@ -101,7 +101,7 @@ public class AuthWrapper implements DiscretePrincipal {
 
 	/*
 	 * (non-Javadoc)
-	 *
+	 * 
 	 * @see io.milton.resource.Resource#getUniqueId()
 	 */
 	@Override
@@ -111,7 +111,7 @@ public class AuthWrapper implements DiscretePrincipal {
 
 	/*
 	 * (non-Javadoc)
-	 *
+	 * 
 	 * @see io.milton.principal.DiscretePrincipal#getPrincipalURL()
 	 */
 	@Override

--- a/src/main/java/org/irods/jargon/webdav/authfilter/BasicAuthFilter.java
+++ b/src/main/java/org/irods/jargon/webdav/authfilter/BasicAuthFilter.java
@@ -44,7 +44,7 @@ public class BasicAuthFilter implements Filter {
 
 	/*
 	 * (non-Javadoc)
-	 *
+	 * 
 	 * @see javax.servlet.Filter#init(javax.servlet.FilterConfig)
 	 */
 	@Override
@@ -54,14 +54,14 @@ public class BasicAuthFilter implements Filter {
 
 	/*
 	 * (non-Javadoc)
-	 *
+	 * 
 	 * @see javax.servlet.Filter#doFilter(javax.servlet.ServletRequest,
 	 * javax.servlet.ServletResponse, javax.servlet.FilterChain)
 	 */
 	@Override
 	public void doFilter(final ServletRequest request,
 			final ServletResponse response, final FilterChain chain)
-					throws IOException, ServletException {
+			throws IOException, ServletException {
 
 		log.debug("doFilter()");
 
@@ -115,7 +115,7 @@ public class BasicAuthFilter implements Filter {
 
 	/*
 	 * (non-Javadoc)
-	 *
+	 * 
 	 * @see javax.servlet.Filter#destroy()
 	 */
 	@Override

--- a/src/main/java/org/irods/jargon/webdav/authfilter/BasicAuthFilter.java
+++ b/src/main/java/org/irods/jargon/webdav/authfilter/BasicAuthFilter.java
@@ -11,10 +11,12 @@ import javax.servlet.FilterConfig;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
+import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.irods.jargon.core.connection.auth.AuthResponse;
+import org.irods.jargon.core.connection.IRODSAccount;
 import org.irods.jargon.core.exception.JargonException;
 import org.irods.jargon.core.pub.IRODSAccessObjectFactory;
 import org.irods.jargon.webdav.config.WebDavConfig;
@@ -86,11 +88,17 @@ public class BasicAuthFilter implements Filter {
 
 			log.debug("authResponse:{}", authResponse);
 			log.debug("success!");
+ 
+            IRODSAccount account = IrodsAccountCacheManager.getInstance().putIRODSAccount(userAndPassword.getUserId(),
+                                                                                          userAndPassword.getPassword(),
+                                                                                          authResponse.getAuthenticatedIRODSAccount());
+           
+            log.debug("authenticated account:{}", account);
 
 			chain.doFilter(httpRequest, httpResponse);
 			return;
 
-		} catch (JargonException e) {
+        } catch (JargonException|IrodsAccountCacheManagerError e) {
 			log.warn("auth exception", e);
 			sendAuthError(httpResponse);
 			return;

--- a/src/main/java/org/irods/jargon/webdav/authfilter/ConnectionClosingFilter.java
+++ b/src/main/java/org/irods/jargon/webdav/authfilter/ConnectionClosingFilter.java
@@ -44,7 +44,7 @@ public class ConnectionClosingFilter implements Filter {
 	@Override
 	public void doFilter(final ServletRequest request,
 			final ServletResponse response, final FilterChain chain)
-			throws IOException, ServletException {
+					throws IOException, ServletException {
 
 		chain.doFilter(request, response);
 		log.debug("closing iRODS connection after filter processing");

--- a/src/main/java/org/irods/jargon/webdav/authfilter/IrodsAccountCacheManager.java
+++ b/src/main/java/org/irods/jargon/webdav/authfilter/IrodsAccountCacheManager.java
@@ -1,0 +1,84 @@
+/**
+ * The class for managing authenticated IRODSAccount's cached in Java Cache System (JCS) 
+ */
+package org.irods.jargon.webdav.authfilter;
+
+import java.util.Arrays;
+import java.math.BigInteger;
+import java.security.MessageDigest;
+
+import org.apache.commons.jcs.JCS;
+import org.apache.commons.jcs.access.CacheAccess;
+import org.irods.jargon.core.connection.IRODSAccount;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class IrodsAccountCacheManager {
+
+    private static IrodsAccountCacheManager instance;
+    private static CacheAccess<String, IRODSAccount> irodsAccountCache;
+	private static final Logger log = LoggerFactory.getLogger(IrodsAccountCacheManager.class);
+
+    private IrodsAccountCacheManager() throws IrodsAccountCacheManagerError  {
+
+        try {
+            irodsAccountCache = JCS.getInstance("irods_account");
+        } catch (Exception e) {
+            throw new IrodsAccountCacheManagerError("cache initialization failed.", e);
+        }
+    }
+
+    public static IrodsAccountCacheManager getInstance() throws IrodsAccountCacheManagerError  {
+
+        synchronized (IrodsAccountCacheManager.class) {
+
+            if (instance == null) {
+                instance = new IrodsAccountCacheManager();
+            }
+        }
+
+        return instance;
+    }
+
+    public IRODSAccount getIRODSAccount(String username, String password)
+        throws IrodsAccountCacheManagerError  {
+        return getIRODSAccount(getAuthId(username,password));
+    }
+
+    public IRODSAccount getIRODSAccount(String authId)
+        throws IrodsAccountCacheManagerError  {
+        return irodsAccountCache.get("IRODSAccount" + authId);
+    }
+
+    public IRODSAccount putIRODSAccount(String username, String password, IRODSAccount account)
+        throws IrodsAccountCacheManagerError  {
+
+        try {
+            irodsAccountCache.put("IRODSAccount" + getAuthId(username,password), account);
+        } catch (Exception e) {
+            throw new IrodsAccountCacheManagerError("cache put failed.", e);
+        }
+
+        // return account from cache
+        return getIRODSAccount(username, password);
+    }
+
+    public static String getAuthId(String username, String password)
+        throws IrodsAccountCacheManagerError  {
+
+        String authId = null;
+
+        try {
+            MessageDigest md = MessageDigest.getInstance("MD5");
+            String data = username + ":" + password;
+            md.update(data.getBytes("UTF-8"));
+            authId = new BigInteger(1, md.digest()).toString(16);
+            log.debug("cache authId: {}", authId);
+        } catch (Exception e) {
+            throw new IrodsAccountCacheManagerError("cache authId generation failed.", e);
+        }
+
+        return authId;
+    }
+}

--- a/src/main/java/org/irods/jargon/webdav/authfilter/IrodsAccountCacheManager.java
+++ b/src/main/java/org/irods/jargon/webdav/authfilter/IrodsAccountCacheManager.java
@@ -48,14 +48,14 @@ public class IrodsAccountCacheManager {
 
     public IRODSAccount getIRODSAccount(String authId)
         throws IrodsAccountCacheManagerError  {
-        return irodsAccountCache.get("IRODSAccount" + authId);
+        return irodsAccountCache.get(authId);
     }
 
     public IRODSAccount putIRODSAccount(String username, String password, IRODSAccount account)
         throws IrodsAccountCacheManagerError  {
 
         try {
-            irodsAccountCache.put("IRODSAccount" + getAuthId(username,password), account);
+            irodsAccountCache.put(getAuthId(username,password), account);
         } catch (Exception e) {
             throw new IrodsAccountCacheManagerError("cache put failed.", e);
         }
@@ -73,7 +73,7 @@ public class IrodsAccountCacheManager {
             MessageDigest md = MessageDigest.getInstance("MD5");
             String data = username + ":" + password;
             md.update(data.getBytes("UTF-8"));
-            authId = new BigInteger(1, md.digest()).toString(16);
+            authId = username + ":" + new BigInteger(1, md.digest()).toString(16);
             log.debug("cache authId: {}", authId);
         } catch (Exception e) {
             throw new IrodsAccountCacheManagerError("cache authId generation failed.", e);

--- a/src/main/java/org/irods/jargon/webdav/authfilter/IrodsAccountCacheManagerError.java
+++ b/src/main/java/org/irods/jargon/webdav/authfilter/IrodsAccountCacheManagerError.java
@@ -1,0 +1,15 @@
+/**
+ * General exception concerning IrodsAccountCacheManager errors 
+ */
+package org.irods.jargon.webdav.authfilter;
+
+public class IrodsAccountCacheManagerError extends Exception {
+
+    public IrodsAccountCacheManagerError(String message) {
+        super(message);
+    }
+
+    public IrodsAccountCacheManagerError(String message, Throwable throwable) {
+        super(message, throwable);
+    }
+}

--- a/src/main/java/org/irods/jargon/webdav/authfilter/IrodsPrincipleId.java
+++ b/src/main/java/org/irods/jargon/webdav/authfilter/IrodsPrincipleId.java
@@ -24,7 +24,7 @@ public class IrodsPrincipleId implements PrincipleId {
 
 	/*
 	 * (non-Javadoc)
-	 *
+	 * 
 	 * @see io.milton.principal.Principal.PrincipleId#getIdType()
 	 */
 	@Override
@@ -35,7 +35,7 @@ public class IrodsPrincipleId implements PrincipleId {
 
 	/*
 	 * (non-Javadoc)
-	 *
+	 * 
 	 * @see io.milton.principal.Principal.PrincipleId#getValue()
 	 */
 	@Override

--- a/src/main/java/org/irods/jargon/webdav/authfilter/WebDavAuthUtils.java
+++ b/src/main/java/org/irods/jargon/webdav/authfilter/WebDavAuthUtils.java
@@ -47,7 +47,7 @@ public class WebDavAuthUtils {
 	 */
 	public static UserAndPassword getAccountFromBasicAuthValues(
 			final String basicAuthData, final WebDavConfig webDavConfig)
-					throws JargonException {
+			throws JargonException {
 
 		log.debug("getIRODSAccountFromBasicAuthValues");
 

--- a/src/main/java/org/irods/jargon/webdav/config/WebDavConfig.java
+++ b/src/main/java/org/irods/jargon/webdav/config/WebDavConfig.java
@@ -17,6 +17,17 @@ public class WebDavConfig {
 	private String defaultStorageResource = "";
 	private String authScheme = AuthScheme.STANDARD.getTextValue();
 	private String realm = "irods";
+
+	/**
+	 * Maximum upload size in Gb
+	 */
+	private long maxUploadInGb = 5;
+
+	/**
+	 * Maximum download size in Gb
+	 */
+	private long maxDownloadInGb = 5;
+
 	/**
 	 * Use an optimization to cache file data (length, etc) preventing requery
 	 * of file data, may cause stale data issues
@@ -123,7 +134,7 @@ public class WebDavConfig {
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see java.lang.Object#toString()
 	 */
 	@Override
@@ -131,49 +142,36 @@ public class WebDavConfig {
 		StringBuilder builder = new StringBuilder();
 		builder.append("WebDavConfig [");
 		if (host != null) {
-			builder.append("host=");
-			builder.append(host);
-			builder.append(", ");
+			builder.append("host=").append(host).append(", ");
 		}
 		if (zone != null) {
-			builder.append("zone=");
-			builder.append(zone);
-			builder.append(", ");
+			builder.append("zone=").append(zone).append(", ");
 		}
-		builder.append("port=");
-		builder.append(port);
-		builder.append(", ");
+		builder.append("port=").append(port).append(", ");
 		if (defaultStorageResource != null) {
-			builder.append("defaultStorageResource=");
-			builder.append(defaultStorageResource);
-			builder.append(", ");
+			builder.append("defaultStorageResource=")
+			.append(defaultStorageResource).append(", ");
 		}
 		if (authScheme != null) {
-			builder.append("authScheme=");
-			builder.append(authScheme);
-			builder.append(", ");
+			builder.append("authScheme=").append(authScheme).append(", ");
 		}
 		if (realm != null) {
-			builder.append("realm=");
-			builder.append(realm);
-			builder.append(", ");
+			builder.append("realm=").append(realm).append(", ");
 		}
-		builder.append("cacheFileDemographics=");
-		builder.append(cacheFileDemographics);
-		builder.append(", ");
+		builder.append("maxUploadInGb=").append(maxUploadInGb)
+		.append(", maxDownloadInGb=").append(maxDownloadInGb)
+		.append(", cacheFileDemographics=")
+		.append(cacheFileDemographics).append(", ");
 		if (defaultStartingLocationEnum != null) {
-			builder.append("defaultStartingLocationEnum=");
-			builder.append(defaultStartingLocationEnum);
-			builder.append(", ");
+			builder.append("defaultStartingLocationEnum=")
+			.append(defaultStartingLocationEnum).append(", ");
 		}
 		if (providedDefaultStartingLocation != null) {
-			builder.append("providedDefaultStartingLocation=");
-			builder.append(providedDefaultStartingLocation);
-			builder.append(", ");
+			builder.append("providedDefaultStartingLocation=")
+			.append(providedDefaultStartingLocation).append(", ");
 		}
-		builder.append("usePackingStreams=");
-		builder.append(usePackingStreams);
-		builder.append("]");
+		builder.append("usePackingStreams=").append(usePackingStreams)
+		.append("]");
 		return builder.toString();
 	}
 
@@ -250,8 +248,38 @@ public class WebDavConfig {
 	 * @param usePackingStreams
 	 *            the usePackingStreams to set
 	 */
-	public void setUsePackingStreams(boolean usePackingStreams) {
+	public void setUsePackingStreams(final boolean usePackingStreams) {
 		this.usePackingStreams = usePackingStreams;
+	}
+
+	/**
+	 * @return the maxUploadInGb
+	 */
+	public long getMaxUploadInGb() {
+		return maxUploadInGb;
+	}
+
+	/**
+	 * @param maxUploadInGb
+	 *            the maxUploadInGb to set
+	 */
+	public void setMaxUploadInGb(final long maxUploadInGb) {
+		this.maxUploadInGb = maxUploadInGb;
+	}
+
+	/**
+	 * @return the maxDownloadInGb
+	 */
+	public long getMaxDownloadInGb() {
+		return maxDownloadInGb;
+	}
+
+	/**
+	 * @param maxDownloadInGb
+	 *            the maxDownloadInGb to set
+	 */
+	public void setMaxDownloadInGb(final long maxDownloadInGb) {
+		this.maxDownloadInGb = maxDownloadInGb;
 	}
 
 }

--- a/src/main/java/org/irods/jargon/webdav/exception/FileSizeExceedsMaximumException.java
+++ b/src/main/java/org/irods/jargon/webdav/exception/FileSizeExceedsMaximumException.java
@@ -1,0 +1,19 @@
+package org.irods.jargon.webdav.exception;
+
+import org.irods.jargon.core.exception.JargonRuntimeException;
+
+/**
+ * File size exceeds a configured maximum
+ *
+ * @author Mike Conway - DICE
+ *
+ */
+public class FileSizeExceedsMaximumException extends JargonRuntimeException {
+
+	private static final long serialVersionUID = 124144366850943280L;
+
+	public FileSizeExceedsMaximumException(final String message) {
+		super(message);
+	}
+
+}

--- a/src/main/java/org/irods/jargon/webdav/resource/BaseResource.java
+++ b/src/main/java/org/irods/jargon/webdav/resource/BaseResource.java
@@ -22,6 +22,7 @@ import org.irods.jargon.core.pub.io.IRODSFile;
 import org.irods.jargon.core.pub.io.IRODSFileFactory;
 import org.irods.jargon.webdav.authfilter.IrodsAuthService;
 import org.irods.jargon.webdav.config.WebDavConfig;
+import org.irods.jargon.webdav.exception.ConfigurationRuntimeException;
 import org.irods.jargon.webdav.exception.WebDavRuntimeException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -90,6 +91,15 @@ CopyableResource, LockableResource {
 			throw new IllegalArgumentException("null webDavConfig");
 		}
 
+		if (factory == null) {
+			throw new IllegalArgumentException("null factory");
+		}
+
+		if (factory.getLockManager() == null) {
+			throw new ConfigurationRuntimeException(
+					"no lock manager configured!");
+		}
+
 		this.irodsAccessObjectFactory = irodsAccessObjectFactory;
 		this.webDavConfig = webDavConfig;
 		this.factory = factory;
@@ -156,6 +166,9 @@ CopyableResource, LockableResource {
 
 	protected IRODSFile fileFromCollectionResource(
 			final CollectionResource collectionResource, final String name) {
+
+		log.info("fileFromCollectionResource()");
+
 		if (collectionResource == null) {
 			throw new IllegalArgumentException("null collectionResource");
 		}
@@ -167,6 +180,7 @@ CopyableResource, LockableResource {
 		IRODSFile dest;
 
 		if (collectionResource instanceof IrodsDirectoryResource) {
+			log.info("is a directory resource");
 			try {
 				IrodsDirectoryResource newFsParent = (IrodsDirectoryResource) collectionResource;
 

--- a/src/main/java/org/irods/jargon/webdav/resource/IrodsDirectoryResource.java
+++ b/src/main/java/org/irods/jargon/webdav/resource/IrodsDirectoryResource.java
@@ -65,9 +65,9 @@ import org.slf4j.LoggerFactory;
  *
  */
 public class IrodsDirectoryResource extends BaseResource implements
-		CollectionResource, MakeCollectionableResource, PutableResource,
-		CopyableResource, DeletableResource, MoveableResource, GetableResource,
-		PropFindableResource, LockingCollectionResource, LockableResource {
+CollectionResource, MakeCollectionableResource, PutableResource,
+CopyableResource, DeletableResource, MoveableResource, GetableResource,
+PropFindableResource, LockingCollectionResource, LockableResource {
 
 	private static final Logger log = LoggerFactory
 			.getLogger(IrodsDirectoryResource.class);
@@ -98,7 +98,7 @@ public class IrodsDirectoryResource extends BaseResource implements
 		}
 		setIrodsFile(dir);
 		this.host = host;
-		this.collectionAndDataObjectListingEntry = null;
+		collectionAndDataObjectListingEntry = null;
 	}
 
 	/**
@@ -106,7 +106,7 @@ public class IrodsDirectoryResource extends BaseResource implements
 	 * <code>CollectionAndDataObjectListingEntry</code>. This will trigger a
 	 * caching behavior for some file demographics which can result in 'stale'
 	 * data, while limiting queries to the catalog and increasing performance.
-	 * 
+	 *
 	 * @param host
 	 * @param factory
 	 * @param dir
@@ -183,7 +183,7 @@ public class IrodsDirectoryResource extends BaseResource implements
 	@Override
 	public List<? extends Resource> getChildren() {
 		log.info("getChildren()");
-		if (this.getWebDavConfig().isCacheFileDemographics()) {
+		if (getWebDavConfig().isCacheFileDemographics()) {
 			return getChildrenUtilizingCaching();
 		} else {
 			return getChildrenViaFile();
@@ -193,16 +193,15 @@ public class IrodsDirectoryResource extends BaseResource implements
 	/**
 	 * Method to get children that will cache file information. This can avoid
 	 * additional queries for things like file length
-	 * 
+	 *
 	 * @return
 	 */
 	private List<? extends Resource> getChildrenUtilizingCaching() {
 		log.info("getChildrenUtilizingCaching()");
 		try {
-			CollectionAndDataObjectListAndSearchAO collectionAndDataObjectListAndSearchAO = this
-					.getIrodsAccessObjectFactory()
+			CollectionAndDataObjectListAndSearchAO collectionAndDataObjectListAndSearchAO = getIrodsAccessObjectFactory()
 					.getCollectionAndDataObjectListAndSearchAO(
-							this.retrieveIrodsAccount());
+							retrieveIrodsAccount());
 
 			log.info("getting collections");
 			List<CollectionAndDataObjectListingEntry> entries = null;
@@ -211,8 +210,7 @@ public class IrodsDirectoryResource extends BaseResource implements
 			int count = 0;
 			while (more) {
 				log.info("querying child collections starting at:{}", count);
-				log.info("under parent:{}", this.getIrodsFile()
-						.getAbsolutePath());
+				log.info("under parent:{}", getIrodsFile().getAbsolutePath());
 				entries = collectionAndDataObjectListAndSearchAO
 						.listCollectionsUnderPath(getIrodsFile()
 								.getAbsolutePath(), count);
@@ -222,12 +220,11 @@ public class IrodsDirectoryResource extends BaseResource implements
 				}
 
 				for (CollectionAndDataObjectListingEntry entry : entries) {
-					IRODSFile childFile = this
-							.instanceIrodsFileFactory()
+					IRODSFile childFile = instanceIrodsFileFactory()
 							.instanceIRODSFile(entry.getFormattedAbsolutePath());
 					IrodsDirectoryResource fileResource = new IrodsDirectoryResource(
-							this.host, this.getFactory(), childFile, entry,
-							this.contentService);
+							host, getFactory(), childFile, entry,
+							contentService);
 					resources.add(fileResource);
 					if (entry.isLastResult()) {
 						more = false;
@@ -240,8 +237,7 @@ public class IrodsDirectoryResource extends BaseResource implements
 			count = 0;
 			while (more) {
 				log.info("querying child files starting at:{}", count);
-				log.info("under parent:{}", this.getIrodsFile()
-						.getAbsolutePath());
+				log.info("under parent:{}", getIrodsFile().getAbsolutePath());
 				entries = collectionAndDataObjectListAndSearchAO
 						.listDataObjectsUnderPath(getIrodsFile()
 								.getAbsolutePath(), count);
@@ -251,12 +247,11 @@ public class IrodsDirectoryResource extends BaseResource implements
 				}
 
 				for (CollectionAndDataObjectListingEntry entry : entries) {
-					IRODSFile childFile = this
-							.instanceIrodsFileFactory()
+					IRODSFile childFile = instanceIrodsFileFactory()
 							.instanceIRODSFile(entry.getFormattedAbsolutePath());
 					IrodsFileResource fileResource = new IrodsFileResource(
-							this.host, this.getFactory(), childFile, entry,
-							this.contentService);
+							host, getFactory(), childFile, entry,
+							contentService);
 					resources.add(fileResource);
 					if (entry.isLastResult()) {
 						more = false;
@@ -279,7 +274,7 @@ public class IrodsDirectoryResource extends BaseResource implements
 	/**
 	 * Method to get children that will not cache file information, may be more
 	 * timely,but necessitates multiple individual queries
-	 * 
+	 *
 	 * @return
 	 */
 	private List<? extends Resource> getChildrenViaFile() {
@@ -336,7 +331,7 @@ public class IrodsDirectoryResource extends BaseResource implements
 	@Override
 	public void sendContent(final OutputStream out, final Range range,
 			final Map<String, String> params, final String contentType)
-			throws IOException, NotAuthorizedException {
+					throws IOException, NotAuthorizedException {
 
 		String subpath = getIrodsFile().getCanonicalPath();
 		if (getIrodsFile().getCanonicalPath().length() > 1) {
@@ -381,11 +376,11 @@ public class IrodsDirectoryResource extends BaseResource implements
 			w.open("td");
 			String path = buildHref(uri, r.getName());
 			w.begin("a").writeAtt("href", path).open().writeText(r.getName())
-					.close();
+			.close();
 
 			w.begin("a").writeAtt("href", "#")
-					.writeAtt("onclick", "editDocument('" + path + "')").open()
-					.writeText("(edit with office)").close();
+			.writeAtt("onclick", "editDocument('" + path + "')").open()
+			.writeText("(edit with office)").close();
 
 			w.close("td");
 
@@ -443,8 +438,8 @@ public class IrodsDirectoryResource extends BaseResource implements
 	@Override
 	public Date getModifiedDate() {
 
-		if (this.collectionAndDataObjectListingEntry != null) {
-			return this.collectionAndDataObjectListingEntry.getModifiedAt();
+		if (collectionAndDataObjectListingEntry != null) {
+			return collectionAndDataObjectListingEntry.getModifiedAt();
 		} else {
 
 			IRODSFile file;
@@ -461,7 +456,7 @@ public class IrodsDirectoryResource extends BaseResource implements
 
 	@Override
 	public String getName() {
-		if (this.collectionAndDataObjectListingEntry != null) {
+		if (collectionAndDataObjectListingEntry != null) {
 			return MiscIRODSUtils
 					.getLastPathComponentForGiveAbsolutePath(collectionAndDataObjectListingEntry
 							.getFormattedAbsolutePath());
@@ -480,7 +475,7 @@ public class IrodsDirectoryResource extends BaseResource implements
 
 	@Override
 	public String getUniqueId() {
-		if (this.collectionAndDataObjectListingEntry != null) {
+		if (collectionAndDataObjectListingEntry != null) {
 			return collectionAndDataObjectListingEntry
 					.getFormattedAbsolutePath();
 		} else {
@@ -544,7 +539,7 @@ public class IrodsDirectoryResource extends BaseResource implements
 
 	@Override
 	public void delete() throws NotAuthorizedException, ConflictException,
-			BadRequestException {
+	BadRequestException {
 
 		log.info("delete()");
 		log.info("of collection:{}", getIrodsFile());
@@ -625,17 +620,16 @@ public class IrodsDirectoryResource extends BaseResource implements
 	@Override
 	public LockToken createAndLock(final String name,
 			final LockTimeout lockTimeout, final LockInfo lockInfo)
-			throws NotAuthorizedException {
+					throws NotAuthorizedException {
+		log.info("createAndLock()");
+		log.info("name:{}", name);
 		IRODSFile file;
 		try {
 			file = instanceIrodsFileFactory().instanceIRODSFile(
 					getIrodsFile().getAbsolutePath(), name);
-			file.createNewFile();
-
+			// file.createNewFile();
+			log.info("new file created");
 		} catch (JargonException e) {
-			log.error("error in create file operation", e);
-			throw new WebDavRuntimeException("unable to create file", e);
-		} catch (IOException e) {
 			log.error("error in create file operation", e);
 			throw new WebDavRuntimeException("unable to create file", e);
 		}

--- a/src/main/java/org/irods/jargon/webdav/resource/IrodsFileResource.java
+++ b/src/main/java/org/irods/jargon/webdav/resource/IrodsFileResource.java
@@ -54,13 +54,14 @@ import org.irods.jargon.core.exception.JargonException;
 import org.irods.jargon.core.pub.DataTransferOperations;
 import org.irods.jargon.core.pub.io.IRODSFile;
 import org.irods.jargon.core.query.CollectionAndDataObjectListingEntry;
+import org.irods.jargon.webdav.exception.ConfigurationRuntimeException;
 import org.irods.jargon.webdav.exception.WebDavRuntimeException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class IrodsFileResource extends BaseResource implements
-		CopyableResource, DeletableResource, GetableResource, MoveableResource,
-		ReplaceableResource, PropFindableResource, LockableResource {
+CopyableResource, DeletableResource, GetableResource, MoveableResource,
+ReplaceableResource, PropFindableResource, LockableResource {
 	private static final Logger log = LoggerFactory
 			.getLogger(IrodsFileResource.class);
 
@@ -96,7 +97,7 @@ public class IrodsFileResource extends BaseResource implements
 	/**
 	 * Constructor takes a parameter that will provided cached values for
 	 * collection and data object listing entries
-	 * 
+	 *
 	 * @param host
 	 * @param factory
 	 * @param file
@@ -151,7 +152,7 @@ public class IrodsFileResource extends BaseResource implements
 	@Override
 	public void sendContent(final OutputStream out, final Range range,
 			final Map<String, String> params, final String contentType)
-			throws IOException, NotFoundException {
+					throws IOException, NotFoundException {
 		log.info("sendContent()");
 		InputStream in = null;
 		try {
@@ -185,6 +186,7 @@ public class IrodsFileResource extends BaseResource implements
 	 */
 	@Override
 	public Long getMaxAgeSeconds(final Auth auth) {
+		log.info("getMaxAgeSeconds()");
 		return getFactory().getMaxAgeSeconds();
 	}
 
@@ -250,7 +252,7 @@ public class IrodsFileResource extends BaseResource implements
 
 	@Override
 	public void delete() throws NotAuthorizedException, ConflictException,
-			BadRequestException {
+	BadRequestException {
 
 		log.info("delete()");
 		getIrodsFile().delete();
@@ -260,6 +262,7 @@ public class IrodsFileResource extends BaseResource implements
 
 	@Override
 	protected void doCopy(final IRODSFile dest) {
+		log.info("doCopy()");
 		log.info("dest:{}", dest);
 
 		try {
@@ -297,22 +300,36 @@ public class IrodsFileResource extends BaseResource implements
 	@Override
 	public LockResult lock(final LockTimeout timeout, final LockInfo lockInfo)
 			throws NotAuthorizedException {
+		log.info("lock()");
+		if (getFactory().getLockManager() == null) {
+			log.error("unable to get lock manager from factory");
+			throw new ConfigurationRuntimeException(
+					"a lock manager was not configured");
+		}
 		return getFactory().getLockManager().lock(timeout, lockInfo, this);
 	}
 
 	@Override
 	public LockResult refreshLock(final String token)
 			throws NotAuthorizedException {
+		log.info("refreshLock()");
 		return getFactory().getLockManager().refresh(token, this);
 	}
 
 	@Override
 	public void unlock(final String tokenId) throws NotAuthorizedException {
+		log.info("unlock");
 		getFactory().getLockManager().unlock(tokenId, this);
 	}
 
 	@Override
 	public LockToken getCurrentLock() {
+		log.info("getCurrentLock()");
+		if (getFactory().getLockManager() == null) {
+			log.error("unable to get lock manager from factory");
+			throw new ConfigurationRuntimeException(
+					"a lock manager was not configured");
+		}
 		if (getFactory().getLockManager() != null) {
 			return getFactory().getLockManager().getCurrentToken(this);
 		} else {

--- a/src/main/java/org/irods/jargon/webdav/resource/IrodsFileSystemResourceFactory.java
+++ b/src/main/java/org/irods/jargon/webdav/resource/IrodsFileSystemResourceFactory.java
@@ -21,9 +21,9 @@ import org.slf4j.LoggerFactory;
 
 /**
  * A resource factory which provides access to files in a file system.
- * 
+ *
  * Using this with milton is equivalent to using the dav servlet in tomcat
- * 
+ *
  */
 public final class IrodsFileSystemResourceFactory implements ResourceFactory {
 
@@ -46,13 +46,13 @@ public final class IrodsFileSystemResourceFactory implements ResourceFactory {
 	 * Creates and (optionally) initialises the factory. This looks for a
 	 * properties file FileSystemResourceFactory.properties in the classpath If
 	 * one is found it uses the root and realm properties to initialise
-	 * 
+	 *
 	 * If not found the factory is initialised with the defaults root: user.home
 	 * system property realm: milton-fs-test
-	 * 
+	 *
 	 * These initialised values are not final, and may be changed through the
 	 * setters or init method
-	 * 
+	 *
 	 */
 	public IrodsFileSystemResourceFactory() {
 		log.debug("setting default configuration...");
@@ -74,8 +74,8 @@ public final class IrodsFileSystemResourceFactory implements ResourceFactory {
 	}
 
 	/**
-	 * 
-	 * 
+	 *
+	 *
 	 * @param securityManager
 	 */
 	public IrodsFileSystemResourceFactory(
@@ -85,8 +85,8 @@ public final class IrodsFileSystemResourceFactory implements ResourceFactory {
 	}
 
 	/**
-	 * 
-	 * 
+	 *
+	 *
 	 * @param securityManager
 	 * @param contextPath
 	 *            - this is the leading part of URL's to ignore. For example if
@@ -135,9 +135,45 @@ public final class IrodsFileSystemResourceFactory implements ResourceFactory {
 		return r;
 	}
 
+	/*
+	 * (non-Javadoc)
+	 *
+	 * @see java.lang.Object#toString()
+	 */
+	@Override
+	public String toString() {
+		StringBuilder builder = new StringBuilder();
+		builder.append("IrodsFileSystemResourceFactory [irodsFileContentService=");
+		builder.append(irodsFileContentService);
+		builder.append(", securityManager=");
+		builder.append(securityManager);
+		builder.append(", lockManager=");
+		builder.append(lockManager);
+		builder.append(", maxAgeSeconds=");
+		builder.append(maxAgeSeconds);
+		builder.append(", contextPath=");
+		builder.append(contextPath);
+		builder.append(", allowDirectoryBrowsing=");
+		builder.append(allowDirectoryBrowsing);
+		builder.append(", defaultPage=");
+		builder.append(defaultPage);
+		builder.append(", digestAllowed=");
+		builder.append(digestAllowed);
+		builder.append(", ssoPrefix=");
+		builder.append(ssoPrefix);
+		builder.append(", irodsAccessObjectFactory=");
+		builder.append(irodsAccessObjectFactory);
+		builder.append(", irodsFileSystem=");
+		builder.append(irodsFileSystem);
+		builder.append(", webDavConfig=");
+		builder.append(webDavConfig);
+		builder.append("]");
+		return builder.toString();
+	}
+
 	/**
 	 * Find the right base path to use based on the provided configuration
-	 * 
+	 *
 	 * @return
 	 */
 	protected String getBasePathBasedOnConfig() {
@@ -176,13 +212,13 @@ public final class IrodsFileSystemResourceFactory implements ResourceFactory {
 		try {
 			IRODSFile f = getIrodsAccessObjectFactory().getIRODSFileFactory(
 					IrodsAuthService.retrieveCurrentIrodsAccount())
-					.instanceIRODSFile(this.getBasePathBasedOnConfig());
+					.instanceIRODSFile(getBasePathBasedOnConfig());
 
 			/*
 			 * the path will have any existing prefix trimmed off when requested
 			 * by the client, as the root was set elsewhere, and all paths are
 			 * expected to be under that prefix.
-			 * 
+			 *
 			 * So if my webDavConfig is set to base on user home, the
 			 * pathToResolve may be /zone/home/user/subdir/blah, and I want to
 			 * Just access /subdir/blah
@@ -221,13 +257,13 @@ public final class IrodsFileSystemResourceFactory implements ResourceFactory {
 		if (s == null) {
 			throw new NullPointerException(
 					"Got null realm from securityManager: " + securityManager
-							+ " for host=" + host);
+					+ " for host=" + host);
 		}
 		return s;
 	}
 
 	/**
-	 * 
+	 *
 	 * @return - the caching time for files
 	 */
 	public Long maxAgeSeconds(final FsResource resource) {
@@ -274,7 +310,7 @@ public final class IrodsFileSystemResourceFactory implements ResourceFactory {
 
 	/**
 	 * Whether to generate an index page.
-	 * 
+	 *
 	 * @return
 	 */
 	public boolean isAllowDirectoryBrowsing() {
@@ -288,7 +324,7 @@ public final class IrodsFileSystemResourceFactory implements ResourceFactory {
 	/**
 	 * if provided GET requests to a folder will redirect to a page of this name
 	 * within the folder
-	 * 
+	 *
 	 * @return - E.g. index.html
 	 */
 	public String getDefaultPage() {
@@ -348,7 +384,7 @@ public final class IrodsFileSystemResourceFactory implements ResourceFactory {
 	/**
 	 * @param irodsFileContentService
 	 *            if (webDavConfig.getDefaultStartingLocationEnum() != )
-	 * 
+	 *
 	 *            the irodsFileContentService to set
 	 */
 	public void setIrodsFileContentService(

--- a/src/main/java/org/irods/jargon/webdav/resource/IrodsSecurityManager.java
+++ b/src/main/java/org/irods/jargon/webdav/resource/IrodsSecurityManager.java
@@ -50,7 +50,7 @@ public class IrodsSecurityManager implements SecurityManager {
 
 	/*
 	 * (non-Javadoc)
-	 *
+	 * 
 	 * @see
 	 * io.milton.http.SecurityManager#authenticate(io.milton.http.http11.auth
 	 * .DigestResponse)
@@ -62,7 +62,7 @@ public class IrodsSecurityManager implements SecurityManager {
 
 	/*
 	 * (non-Javadoc)
-	 *
+	 * 
 	 * @see io.milton.http.SecurityManager#authenticate(java.lang.String,
 	 * java.lang.String)
 	 */
@@ -90,7 +90,7 @@ public class IrodsSecurityManager implements SecurityManager {
 
 	/*
 	 * (non-Javadoc)
-	 *
+	 * 
 	 * @see io.milton.http.SecurityManager#authorise(io.milton.http.Request,
 	 * io.milton.http.Request.Method, io.milton.http.Auth,
 	 * io.milton.resource.Resource)
@@ -103,7 +103,7 @@ public class IrodsSecurityManager implements SecurityManager {
 
 	/*
 	 * (non-Javadoc)
-	 *
+	 * 
 	 * @see io.milton.http.SecurityManager#getRealm(java.lang.String)
 	 */
 	@Override
@@ -114,7 +114,7 @@ public class IrodsSecurityManager implements SecurityManager {
 
 	/*
 	 * (non-Javadoc)
-	 *
+	 * 
 	 * @see io.milton.http.SecurityManager#isDigestAllowed()
 	 */
 	@Override

--- a/src/main/java/org/irods/jargon/webdav/resource/IrodsSecurityManager.java
+++ b/src/main/java/org/irods/jargon/webdav/resource/IrodsSecurityManager.java
@@ -40,7 +40,7 @@ public class IrodsSecurityManager implements SecurityManager {
 	private static final Logger log = LoggerFactory
 			.getLogger(IrodsSecurityManager.class);
 
-	private static final ThreadLocal<AuthResponse> authResponseCache = new ThreadLocal<AuthResponse>();
+	//private static final ThreadLocal<AuthResponse> authResponseCache = new ThreadLocal<AuthResponse>();
 
 	/**
 	 *
@@ -69,13 +69,13 @@ public class IrodsSecurityManager implements SecurityManager {
 	@Override
 	public Object authenticate(final String userName, final String password) {
 		log.info("authenticate()");
-		clearThreadlocals();
+		//clearThreadlocals();
 
 		try {
 			AuthResponse authResponse = irodsAuthService.authenticate(userName,
 					password);
-			log.info("storing authResponse in threadlocal as authResponseCache");
-			authResponseCache.set(authResponse);
+			//log.info("storing authResponse in threadlocal as authResponseCache");
+			//authResponseCache.set(authResponse);
 			return authResponse;
 		} catch (AuthenticationException e) {
 			log.info("authentication failed", e);
@@ -168,8 +168,10 @@ public class IrodsSecurityManager implements SecurityManager {
 		this.irodsAuthService = irodsAuthService;
 	}
 
+    /*
 	public static void clearThreadlocals() {
 		authResponseCache.remove();
 	}
+    */
 
 }

--- a/src/main/java/org/irods/jargon/webdav/resource/SimpleLockManager.java
+++ b/src/main/java/org/irods/jargon/webdav/resource/SimpleLockManager.java
@@ -75,7 +75,7 @@ public class SimpleLockManager implements LockManager {
 		String lockedBy = lock.lockedByUser;
 		Long secs = lock.token.timeout.getSeconds();
 		return id + "\n" + token + "\n" + tm + "\n" + lockedBy + "\n"
-		+ (secs != null ? secs : "");
+				+ (secs != null ? secs : "");
 	}
 
 	/**

--- a/src/main/java/org/irods/jargon/webdav/utils/IrodsWebdavVersion.java
+++ b/src/main/java/org/irods/jargon/webdav/utils/IrodsWebdavVersion.java
@@ -1,0 +1,5 @@
+package org.irods.jargon.webdav.utils;
+public final class IrodsWebdavVersion {
+ public static String VERSION="0.0.1-SNAPSHOT";
+ public static String BUILD_TIME="2015-08-10T08:45:36Z";
+}

--- a/src/main/resources/cache.ccf
+++ b/src/main/resources/cache.ccf
@@ -5,11 +5,21 @@ jcs.default.cacheattributes=org.apache.commons.jcs.engine.CompositeCacheAttribut
 jcs.default.cacheattributes.MaxObjects=1000
 jcs.default.cacheattributes.MemoryCacheName=org.apache.commons.jcs.engine.memory.lru.LRUMemoryCache
 
-# REGION irods_account
+# REGION irods_account using "Remote" auxiliary
+jcs.region.irods_account=Remote
+jcs.region.irods_account.cacheattributes.MaxObjects=100
 jcs.region.irods_account.cacheattributes.UseMemoryShrinker=true
 jcs.region.irods_account.cacheattributes.MaxMemoryIdleTime=3600
 jcs.region.irods_account.cacheattributes.ShrinkerInterval=60
 jcs.region.irods_account.elementattributes=org.apache.commons.jcs.engine.ElementAttributes
-jcs.region.irods_account.elementattributes.IsEternal=false
 jcs.region.irods_account.elementattributes.MaxLife=7200
 jcs.region.irods_account.elementattributes.IdleTime=1800
+jcs.region.irods_account.elementattributes.IsEternal=false
+jcs.region.irods_account.elementattributes.IsRemote=true
+
+# Remote RMI Cache setup
+jcs.auxiliary.Remote=org.apache.commons.jcs.auxiliary.remote.RemoteCacheFactory
+jcs.auxiliary.Remote.attributes=org.apache.commons.jcs.auxiliary.remote.RemoteCacheAttributes
+jcs.auxiliary.Remote.attributes.FailoverServers=localhost:1101
+jcs.auxiliary.Remote.attributes.RemoveUponRemotePut=true
+jcs.auxiliary.Remote.attributes.GetOnly=false

--- a/src/main/resources/cache.ccf
+++ b/src/main/resources/cache.ccf
@@ -1,0 +1,15 @@
+# DEFAULT CACHE REGION
+
+jcs.default=
+jcs.default.cacheattributes=org.apache.commons.jcs.engine.CompositeCacheAttributes
+jcs.default.cacheattributes.MaxObjects=1000
+jcs.default.cacheattributes.MemoryCacheName=org.apache.commons.jcs.engine.memory.lru.LRUMemoryCache
+
+# REGION irods_account
+jcs.region.irods_account.cacheattributes.UseMemoryShrinker=true
+jcs.region.irods_account.cacheattributes.MaxMemoryIdleTime=3600
+jcs.region.irods_account.cacheattributes.ShrinkerInterval=60
+jcs.region.irods_account.elementattributes=org.apache.commons.jcs.engine.ElementAttributes
+jcs.region.irods_account.elementattributes.IsEternal=false
+jcs.region.irods_account.elementattributes.MaxLife=7200
+jcs.region.irods_account.elementattributes.IdleTime=1800

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -1,5 +1,5 @@
 # Set root logger level to DEBUG and its only appender to A1.
-log4j.rootLogger=WARN, A1
+log4j.rootLogger=INFO, A1
 log4j.logger.org.irods.jargon.webdav=DEBUG
 log4j.logger.org.irods.jargon.core.pub=INFO
 log4j.logger.org.irods.jargon.core.pub.io=INFO

--- a/src/main/resources/milton-beans.xml
+++ b/src/main/resources/milton-beans.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+
+	<bean id="irodsFileContentService"
+		class="org.irods.jargon.webdav.resource.IrodsFileContentService">
+		<property name="irodsAccessObjectFactory" ref="irodsAccessObjectFactory" />
+		<property name="webDavConfig" ref="webDavConfig"/>
+	</bean>
+
+	<bean id="webDavConfig" class="org.irods.jargon.webdav.config.WebDavConfig">
+		<property name="host" value="${irods.host}" />
+		<property name="zone" value="${irods.zone}" />
+		<property name="port" value="${irods.port}" />
+		<property name="authScheme" value="${auth.type}" />
+		<property name="defaultStorageResource" value="${default.storage.resource}" />
+		<property name="defaultStartingLocationEnum" value="${default.starting.location}" />
+		<property name="providedDefaultStartingLocation" value="${provided.starting.location.path}" />
+		<property name="cacheFileDemographics" value="${cache.file.demographics}" />
+		<property name="usePackingStreams" value="${utilize.packing.streams}" />
+		<property name="maxUploadInGb" value="${max.upload.in.gb}"/>
+		<property name="maxDownloadInGb" value="${max.download.in.gb}"/>
+	</bean>
+
+	<bean id="irodsSecurityManager" class="org.irods.jargon.webdav.resource.IrodsSecurityManager">
+		<property name="irodsAccessObjectFactory" ref="irodsAccessObjectFactory" />
+		<property name="webDavConfig" ref="webDavConfig" />
+		<property name="irodsAuthService" ref="irodsAuthService" />
+	</bean>
+
+	<bean id="irodsAuthService" class="org.irods.jargon.webdav.authfilter.IrodsAuthService">
+		<property name="irodsAccessObjectFactory" ref="irodsAccessObjectFactory" />
+		<property name="webDavConfig" ref="webDavConfig" />
+	</bean>
+	
+	<!-- 	<bean id="lockManager" class="org.irods.jargon.webdav.resource.IrodsMemoryLockManager"></bean>
+	 -->
+	
+	<bean id="lockManager" class="io.milton.http.fs.SimpleLockManager">
+		<constructor-arg type="io.milton.cache.CacheManager"
+			ref="cacheManager" />
+	</bean>
+
+	<bean id="resource.factory"
+		class="org.irods.jargon.webdav.resource.IrodsFileSystemResourceFactory">
+		<constructor-arg type="io.milton.http.SecurityManager"
+			ref="irodsSecurityManager" />
+		<property name="irodsAccessObjectFactory" ref="irodsAccessObjectFactory" />
+		<property name="webDavConfig" ref="webDavConfig" />
+		<property name="contextPath" value="irods-webdav" />
+		<property name="contentService" ref="irodsFileContentService" />
+		<property name="lockManager" ref="lockManager" />
+	</bean>
+	
+	<bean id="cacheManager" class="io.milton.cache.LocalCacheManager"/>
+
+<!-- <bean id="milton.http.manager" class="io.milton.config.HttpManagerBuilder">
+		<property name="mainResourceFactory" ref="resource.factory" />
+		<property name="enableCompression" value="false" />
+		<property name="buffering" value="never" />
+		<property name="enableCookieAuth" value="false" />
+	</bean> -->
+
+	<bean id="milton.http.manager" class="io.milton.ent.config.HttpManagerBuilderEnt">
+		<property name="mainResourceFactory" ref="resource.factory" />
+		<property name="enableCompression" value="false" />
+		<property name="buffering" value="never" />
+		<property name="enableCookieAuth" value="false" />
+		<property name="lockManager" ref="lockManager" />
+	</bean>
+
+	<bean id="irodsConnectionManager"
+		class="org.irods.jargon.core.connection.IRODSSimpleProtocolManager"
+		factory-method="instance" init-method="initialize" destroy-method="destroy" />
+
+	<bean id="irodsSession" class="org.irods.jargon.core.connection.IRODSSession"
+		factory-method="instance">
+		<constructor-arg
+			type="org.irods.jargon.core.connection.IRODSProtocolManager" ref="irodsConnectionManager" />
+	</bean>
+
+	<bean id="irodsAccessObjectFactory" class="org.irods.jargon.core.pub.IRODSAccessObjectFactoryImpl">
+		<constructor-arg ref="irodsSession" />
+	</bean>
+
+	<bean id="basicAuthFilter" class="org.irods.jargon.webdav.authfilter.BasicAuthFilter">
+		<property name="irodsAccessObjectFactory" ref="irodsAccessObjectFactory" />
+		<property name="webDavConfig" ref="webDavConfig" />
+		<property name="irodsAuthService" ref="irodsAuthService" />
+	</bean>
+	
+	<bean id="connectionClosingFilter" class="org.irods.jargon.webdav.authfilter.ConnectionClosingFilter">
+		<property name="irodsAccessObjectFactory" ref="irodsAccessObjectFactory" />
+	</bean>
+
+
+</beans>

--- a/src/main/resources/miltonContext.xml
+++ b/src/main/resources/miltonContext.xml
@@ -1,80 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://www.springframework.org/schema/beans"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+<beans:beans xmlns="http://www.springframework.org/schema/security"
+	xmlns:beans="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:context="http://www.springframework.org/schema/context"
+	xmlns:sec="http://www.springframework.org/schema/security"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
+                        http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-3.0.xsd http://www.springframework.org/schema/context 
+	http://www.springframework.org/schema/context/spring-context-3.0.xsd">
 
-	<bean id="irodsFileContentService"
-		class="org.irods.jargon.webdav.resource.IrodsFileContentService">
-		<property name="irodsAccessObjectFactory" ref="irodsAccessObjectFactory" />
-		<property name="webDavConfig" ref="webDavConfig"/>
-	</bean>
-
-	<bean id="webDavConfig" class="org.irods.jargon.webdav.config.WebDavConfig">
-		<property name="host" value="dfc-test-irods1.edc.renci.org" />
-		<property name="zone" value="dfc1" />
-		<property name="port" value="1247" />
-		<property name="authScheme" value="STANDARD" />
-		<property name="defaultStorageResource" value="" />
-		<property name="defaultStartingLocationEnum" value="USER_HOME" />
-		<property name="providedDefaultStartingLocation" value="" />
-		<property name="cacheFileDemographics" value="true" />
-		<property name="usePackingStreams" value="true" />
-	</bean>
-
-	<bean id="irodsSecurityManager" class="org.irods.jargon.webdav.resource.IrodsSecurityManager">
-		<property name="irodsAccessObjectFactory" ref="irodsAccessObjectFactory" />
-		<property name="webDavConfig" ref="webDavConfig" />
-		<property name="irodsAuthService" ref="irodsAuthService" />
-	</bean>
-
-	<bean id="irodsAuthService" class="org.irods.jargon.webdav.authfilter.IrodsAuthService">
-		<property name="irodsAccessObjectFactory" ref="irodsAccessObjectFactory" />
-		<property name="webDavConfig" ref="webDavConfig" />
-	</bean>
+	<context:property-placeholder  location="file:///etc/irods-ext/irods-webdav.properties" /> 
+	<beans:import resource="classpath:milton-beans.xml" />
 	
-	<bean id="lockManager" class="org.irods.jargon.webdav.resource.IrodsMemoryLockManager"></bean>
-
-	<bean id="resource.factory"
-		class="org.irods.jargon.webdav.resource.IrodsFileSystemResourceFactory">
-		<constructor-arg type="io.milton.http.SecurityManager"
-			ref="irodsSecurityManager" />
-		<property name="irodsAccessObjectFactory" ref="irodsAccessObjectFactory" />
-		<property name="webDavConfig" ref="webDavConfig" />
-		<property name="contextPath" value="irods-webdav" />
-		<property name="contentService" ref="irodsFileContentService" />
-		<property name="lockManager" ref="lockManager" />
-	</bean>
-
-	<bean id="milton.http.manager" class="io.milton.config.HttpManagerBuilder">
-		<property name="mainResourceFactory" ref="resource.factory" />
-		<property name="enableCompression" value="false" />
-		<property name="buffering" value="never" />
-		<property name="enableCookieAuth" value="false" />
-	</bean>
-
-	<bean id="irodsConnectionManager"
-		class="org.irods.jargon.core.connection.IRODSSimpleProtocolManager"
-		factory-method="instance" init-method="initialize" destroy-method="destroy" />
-
-	<bean id="irodsSession" class="org.irods.jargon.core.connection.IRODSSession"
-		factory-method="instance">
-		<constructor-arg
-			type="org.irods.jargon.core.connection.IRODSProtocolManager" ref="irodsConnectionManager" />
-	</bean>
-
-	<bean id="irodsAccessObjectFactory" class="org.irods.jargon.core.pub.IRODSAccessObjectFactoryImpl">
-		<constructor-arg ref="irodsSession" />
-	</bean>
-
-	<bean id="basicAuthFilter" class="org.irods.jargon.webdav.authfilter.BasicAuthFilter">
-		<property name="irodsAccessObjectFactory" ref="irodsAccessObjectFactory" />
-		<property name="webDavConfig" ref="webDavConfig" />
-		<property name="irodsAuthService" ref="irodsAuthService" />
-	</bean>
-	
-	<bean id="connectionClosingFilter" class="org.irods.jargon.webdav.authfilter.ConnectionClosingFilter">
-		<property name="irodsAccessObjectFactory" ref="irodsAccessObjectFactory" />
-	</bean>
-
-
-</beans>
+</beans:beans>

--- a/src/test/java/org/irods/jargon/webdav/resource/FileContentServiceTest.java
+++ b/src/test/java/org/irods/jargon/webdav/resource/FileContentServiceTest.java
@@ -1,0 +1,149 @@
+package org.irods.jargon.webdav.resource;
+
+import io.milton.http.LockManager;
+
+import java.io.File;
+import java.io.InputStream;
+import java.util.Properties;
+
+import junit.framework.Assert;
+
+import org.irods.jargon.core.connection.IRODSAccount;
+import org.irods.jargon.core.pub.DataTransferOperations;
+import org.irods.jargon.core.pub.IRODSFileSystem;
+import org.irods.jargon.core.pub.io.IRODSFile;
+import org.irods.jargon.testutils.IRODSTestSetupUtilities;
+import org.irods.jargon.testutils.TestingPropertiesHelper;
+import org.irods.jargon.testutils.filemanip.FileGenerator;
+import org.irods.jargon.testutils.filemanip.ScratchFileUtils;
+import org.irods.jargon.webdav.config.WebDavConfig;
+import org.irods.jargon.webdav.exception.FileSizeExceedsMaximumException;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class FileContentServiceTest {
+
+	private static Properties testingProperties = new Properties();
+	private static TestingPropertiesHelper testingPropertiesHelper = new TestingPropertiesHelper();
+	private static ScratchFileUtils scratchFileUtils = null;
+	public static final String IRODS_TEST_SUBDIR_PATH = "FileContentServiceTest";
+	private static IRODSTestSetupUtilities irodsTestSetupUtilities = null;
+	private static IRODSFileSystem irodsFileSystem;
+
+	@BeforeClass
+	public static void setUpBeforeClass() throws Exception {
+		TestingPropertiesHelper testingPropertiesLoader = new TestingPropertiesHelper();
+		testingProperties = testingPropertiesLoader.getTestProperties();
+		scratchFileUtils = new ScratchFileUtils(testingProperties);
+		scratchFileUtils
+		.clearAndReinitializeScratchDirectory(IRODS_TEST_SUBDIR_PATH);
+		irodsTestSetupUtilities = new IRODSTestSetupUtilities();
+		irodsTestSetupUtilities.initializeIrodsScratchDirectory();
+		irodsTestSetupUtilities
+		.initializeDirectoryForTest(IRODS_TEST_SUBDIR_PATH);
+		irodsFileSystem = IRODSFileSystem.instance();
+	}
+
+	@AfterClass
+	public static void tearDownAfterClass() throws Exception {
+		irodsFileSystem.closeAndEatExceptions();
+	}
+
+	@Test
+	public void testDownloadLessThanMax() throws Exception {
+		// generate a local scratch file
+		String testFileName = "testDownloadLessThanMax.txt";
+		String absPath = scratchFileUtils
+				.createAndReturnAbsoluteScratchPath(IRODS_TEST_SUBDIR_PATH);
+		String localFileName = FileGenerator
+				.generateFileOfFixedLengthGivenName(absPath, testFileName, 2);
+
+		String targetIrodsFile = testingPropertiesHelper
+				.buildIRODSCollectionAbsolutePathFromTestProperties(
+						testingProperties, IRODS_TEST_SUBDIR_PATH + '/'
+						+ testFileName);
+		File localFile = new File(localFileName);
+
+		// now put the file
+
+		IRODSAccount irodsAccount = testingPropertiesHelper
+				.buildIRODSAccountFromTestProperties(testingProperties);
+		DataTransferOperations dto = irodsFileSystem
+				.getIRODSAccessObjectFactory().getDataTransferOperations(
+						irodsAccount);
+		IRODSFile destFile = irodsFileSystem.getIRODSFileFactory(irodsAccount)
+				.instanceIRODSFile(targetIrodsFile);
+
+		dto.putOperation(localFile, destFile, null, null);
+
+		IrodsSecurityManager manager = Mockito.mock(IrodsSecurityManager.class);
+
+		IrodsFileSystemResourceFactory factory = new IrodsFileSystemResourceFactory(
+				manager);
+		LockManager lockManager = Mockito.mock(LockManager.class);
+		factory.setLockManager(lockManager);
+
+		WebDavConfig config = new WebDavConfig();
+		factory.setWebDavConfig(config);
+
+		IrodsFileContentService service = new IrodsFileContentService();
+		service.setIrodsAccessObjectFactory(irodsFileSystem
+				.getIRODSAccessObjectFactory());
+		service.setWebDavConfig(config);
+		InputStream actual = service.getFileContent(destFile, irodsAccount);
+		Assert.assertNotNull(actual);
+
+	}
+
+	@Test(expected = FileSizeExceedsMaximumException.class)
+	public void testDownloadGreaterThanMax() throws Exception {
+		// generate a local scratch file
+		String testFileName = "testDownloadGreaterThanMax.txt";
+		long max = 1;
+		long myLength = (long) 2 * 1024 * 1024 * 1024;
+		String absPath = scratchFileUtils
+				.createAndReturnAbsoluteScratchPath(IRODS_TEST_SUBDIR_PATH);
+		String localFileName = FileGenerator
+				.generateFileOfFixedLengthGivenName(absPath, testFileName,
+						myLength);
+
+		String targetIrodsFile = testingPropertiesHelper
+				.buildIRODSCollectionAbsolutePathFromTestProperties(
+						testingProperties, IRODS_TEST_SUBDIR_PATH + '/'
+						+ testFileName);
+		File localFile = new File(localFileName);
+
+		// now put the file
+
+		IRODSAccount irodsAccount = testingPropertiesHelper
+				.buildIRODSAccountFromTestProperties(testingProperties);
+		DataTransferOperations dto = irodsFileSystem
+				.getIRODSAccessObjectFactory().getDataTransferOperations(
+						irodsAccount);
+		IRODSFile destFile = irodsFileSystem.getIRODSFileFactory(irodsAccount)
+				.instanceIRODSFile(targetIrodsFile);
+
+		dto.putOperation(localFile, destFile, null, null);
+
+		IrodsSecurityManager manager = Mockito.mock(IrodsSecurityManager.class);
+
+		IrodsFileSystemResourceFactory factory = new IrodsFileSystemResourceFactory(
+				manager);
+		LockManager lockManager = Mockito.mock(LockManager.class);
+		factory.setLockManager(lockManager);
+
+		WebDavConfig config = new WebDavConfig();
+		config.setMaxDownloadInGb(max);
+		factory.setWebDavConfig(config);
+
+		IrodsFileContentService service = new IrodsFileContentService();
+		service.setIrodsAccessObjectFactory(irodsFileSystem
+				.getIRODSAccessObjectFactory());
+		service.setWebDavConfig(config);
+		service.getFileContent(destFile, irodsAccount);
+
+	}
+
+}

--- a/src/test/java/org/irods/jargon/webdav/resource/IrodsDirectoryResourceTest.java
+++ b/src/test/java/org/irods/jargon/webdav/resource/IrodsDirectoryResourceTest.java
@@ -1,5 +1,6 @@
 package org.irods.jargon.webdav.resource;
 
+import io.milton.http.LockManager;
 import io.milton.resource.Resource;
 
 import java.io.File;
@@ -38,11 +39,11 @@ public class IrodsDirectoryResourceTest {
 		testingProperties = testingPropertiesLoader.getTestProperties();
 		scratchFileUtils = new ScratchFileUtils(testingProperties);
 		scratchFileUtils
-				.clearAndReinitializeScratchDirectory(IRODS_TEST_SUBDIR_PATH);
+		.clearAndReinitializeScratchDirectory(IRODS_TEST_SUBDIR_PATH);
 		irodsTestSetupUtilities = new IRODSTestSetupUtilities();
 		irodsTestSetupUtilities.initializeIrodsScratchDirectory();
 		irodsTestSetupUtilities
-				.initializeDirectoryForTest(IRODS_TEST_SUBDIR_PATH);
+		.initializeDirectoryForTest(IRODS_TEST_SUBDIR_PATH);
 		irodsFileSystem = IRODSFileSystem.instance();
 	}
 
@@ -62,7 +63,7 @@ public class IrodsDirectoryResourceTest {
 		String targetIrodsColl = testingPropertiesHelper
 				.buildIRODSCollectionAbsolutePathFromTestProperties(
 						testingProperties, IRODS_TEST_SUBDIR_PATH + '/'
-								+ testTargetColl);
+						+ testTargetColl);
 
 		IRODSAccount irodsAccount = testingPropertiesHelper
 				.buildIRODSAccountFromTestProperties(testingProperties);
@@ -91,6 +92,8 @@ public class IrodsDirectoryResourceTest {
 
 		IrodsFileSystemResourceFactory factory = new IrodsFileSystemResourceFactory(
 				manager);
+		LockManager lockManager = Mockito.mock(LockManager.class);
+		factory.setLockManager(lockManager);
 
 		factory.setWebDavConfig(config);
 
@@ -119,7 +122,7 @@ public class IrodsDirectoryResourceTest {
 		String targetIrodsColl = testingPropertiesHelper
 				.buildIRODSCollectionAbsolutePathFromTestProperties(
 						testingProperties, IRODS_TEST_SUBDIR_PATH + '/'
-								+ testTargetColl);
+						+ testTargetColl);
 
 		IRODSAccount irodsAccount = testingPropertiesHelper
 				.buildIRODSAccountFromTestProperties(testingProperties);
@@ -150,6 +153,8 @@ public class IrodsDirectoryResourceTest {
 
 		IrodsFileSystemResourceFactory factory = new IrodsFileSystemResourceFactory(
 				manager);
+		LockManager lockManager = Mockito.mock(LockManager.class);
+		factory.setLockManager(lockManager);
 
 		factory.setWebDavConfig(config);
 
@@ -177,7 +182,7 @@ public class IrodsDirectoryResourceTest {
 		String targetIrodsColl = testingPropertiesHelper
 				.buildIRODSCollectionAbsolutePathFromTestProperties(
 						testingProperties, IRODS_TEST_SUBDIR_PATH + '/'
-								+ testTargetColl);
+						+ testTargetColl);
 
 		IRODSAccount irodsAccount = testingPropertiesHelper
 				.buildIRODSAccountFromTestProperties(testingProperties);
@@ -222,6 +227,8 @@ public class IrodsDirectoryResourceTest {
 
 		IrodsFileSystemResourceFactory factory = new IrodsFileSystemResourceFactory(
 				manager);
+		LockManager lockManager = Mockito.mock(LockManager.class);
+		factory.setLockManager(lockManager);
 
 		factory.setWebDavConfig(config);
 
@@ -267,6 +274,8 @@ public class IrodsDirectoryResourceTest {
 
 		IrodsFileSystemResourceFactory factory = new IrodsFileSystemResourceFactory(
 				manager);
+		LockManager lockManager = Mockito.mock(LockManager.class);
+		factory.setLockManager(lockManager);
 
 		factory.setWebDavConfig(config);
 
@@ -293,7 +302,7 @@ public class IrodsDirectoryResourceTest {
 		String targetIrodsColl = testingPropertiesHelper
 				.buildIRODSCollectionAbsolutePathFromTestProperties(
 						testingProperties, IRODS_TEST_SUBDIR_PATH + '/'
-								+ testTargetColl);
+						+ testTargetColl);
 
 		IRODSAccount irodsAccount = testingPropertiesHelper
 				.buildIRODSAccountFromTestProperties(testingProperties);
@@ -338,6 +347,8 @@ public class IrodsDirectoryResourceTest {
 
 		IrodsFileSystemResourceFactory factory = new IrodsFileSystemResourceFactory(
 				manager);
+		LockManager lockManager = Mockito.mock(LockManager.class);
+		factory.setLockManager(lockManager);
 
 		factory.setWebDavConfig(config);
 
@@ -388,6 +399,8 @@ public class IrodsDirectoryResourceTest {
 
 		IrodsFileSystemResourceFactory factory = new IrodsFileSystemResourceFactory(
 				manager);
+		LockManager lockManager = Mockito.mock(LockManager.class);
+		factory.setLockManager(lockManager);
 
 		factory.setWebDavConfig(config);
 
@@ -450,7 +463,8 @@ public class IrodsDirectoryResourceTest {
 
 		IrodsFileSystemResourceFactory factory = new IrodsFileSystemResourceFactory(
 				manager);
-
+		LockManager lockManager = Mockito.mock(LockManager.class);
+		factory.setLockManager(lockManager);
 		factory.setWebDavConfig(config);
 
 		IrodsFileContentService service = new IrodsFileContentService();
@@ -490,7 +504,7 @@ public class IrodsDirectoryResourceTest {
 				.getIRODSFileFactory(irodsAccount)
 				.instanceIRODSFile(
 						MiscIRODSUtils
-								.buildIRODSUserHomeForAccountUsingDefaultScheme(irodsAccount));
+						.buildIRODSUserHomeForAccountUsingDefaultScheme(irodsAccount));
 
 		IRODSFile destFile = irodsFileSystem.getIRODSFileFactory(irodsAccount)
 				.instanceIRODSFile(rootCollection.getAbsolutePath(),
@@ -516,6 +530,9 @@ public class IrodsDirectoryResourceTest {
 
 		IrodsFileSystemResourceFactory factory = new IrodsFileSystemResourceFactory(
 				manager);
+
+		LockManager lockManager = Mockito.mock(LockManager.class);
+		factory.setLockManager(lockManager);
 
 		factory.setWebDavConfig(config);
 

--- a/src/test/java/org/irods/jargon/webdav/resource/IrodsFileResourceTest.java
+++ b/src/test/java/org/irods/jargon/webdav/resource/IrodsFileResourceTest.java
@@ -1,5 +1,7 @@
 package org.irods.jargon.webdav.resource;
 
+import io.milton.http.LockManager;
+
 import java.io.File;
 import java.util.Properties;
 
@@ -34,11 +36,11 @@ public class IrodsFileResourceTest {
 		testingProperties = testingPropertiesLoader.getTestProperties();
 		scratchFileUtils = new ScratchFileUtils(testingProperties);
 		scratchFileUtils
-				.clearAndReinitializeScratchDirectory(IRODS_TEST_SUBDIR_PATH);
+		.clearAndReinitializeScratchDirectory(IRODS_TEST_SUBDIR_PATH);
 		irodsTestSetupUtilities = new IRODSTestSetupUtilities();
 		irodsTestSetupUtilities.initializeIrodsScratchDirectory();
 		irodsTestSetupUtilities
-				.initializeDirectoryForTest(IRODS_TEST_SUBDIR_PATH);
+		.initializeDirectoryForTest(IRODS_TEST_SUBDIR_PATH);
 		irodsFileSystem = IRODSFileSystem.instance();
 	}
 
@@ -59,7 +61,7 @@ public class IrodsFileResourceTest {
 		String targetIrodsFile = testingPropertiesHelper
 				.buildIRODSCollectionAbsolutePathFromTestProperties(
 						testingProperties, IRODS_TEST_SUBDIR_PATH + '/'
-								+ testFileName);
+						+ testFileName);
 		File localFile = new File(localFileName);
 
 		// now put the file
@@ -78,6 +80,8 @@ public class IrodsFileResourceTest {
 
 		IrodsFileSystemResourceFactory factory = new IrodsFileSystemResourceFactory(
 				manager);
+		LockManager lockManager = Mockito.mock(LockManager.class);
+		factory.setLockManager(lockManager);
 
 		WebDavConfig config = new WebDavConfig();
 		factory.setWebDavConfig(config);
@@ -104,7 +108,7 @@ public class IrodsFileResourceTest {
 		String targetIrodsFile = testingPropertiesHelper
 				.buildIRODSCollectionAbsolutePathFromTestProperties(
 						testingProperties, IRODS_TEST_SUBDIR_PATH + '/'
-								+ testFileName);
+						+ testFileName);
 		File localFile = new File(localFileName);
 
 		// now put the file
@@ -123,6 +127,8 @@ public class IrodsFileResourceTest {
 
 		IrodsFileSystemResourceFactory factory = new IrodsFileSystemResourceFactory(
 				manager);
+		LockManager lockManager = Mockito.mock(LockManager.class);
+		factory.setLockManager(lockManager);
 
 		WebDavConfig config = new WebDavConfig();
 		factory.setWebDavConfig(config);
@@ -149,7 +155,7 @@ public class IrodsFileResourceTest {
 		String targetIrodsFile = testingPropertiesHelper
 				.buildIRODSCollectionAbsolutePathFromTestProperties(
 						testingProperties, IRODS_TEST_SUBDIR_PATH + '/'
-								+ testFileName);
+						+ testFileName);
 		File localFile = new File(localFileName);
 
 		// now put the file
@@ -168,6 +174,9 @@ public class IrodsFileResourceTest {
 
 		IrodsFileSystemResourceFactory factory = new IrodsFileSystemResourceFactory(
 				manager);
+
+		LockManager lockManager = Mockito.mock(LockManager.class);
+		factory.setLockManager(lockManager);
 
 		WebDavConfig config = new WebDavConfig();
 		factory.setWebDavConfig(config);
@@ -196,16 +205,16 @@ public class IrodsFileResourceTest {
 		String targetIrodsColl = testingPropertiesHelper
 				.buildIRODSCollectionAbsolutePathFromTestProperties(
 						testingProperties, IRODS_TEST_SUBDIR_PATH + '/'
-								+ testTargetColl);
+						+ testTargetColl);
 
 		String targetIrodsFile = testingPropertiesHelper
 				.buildIRODSCollectionAbsolutePathFromTestProperties(
 						testingProperties, IRODS_TEST_SUBDIR_PATH + '/'
-								+ testFileName);
+						+ testFileName);
 		String targetIrodsFileMoveTo = testingPropertiesHelper
 				.buildIRODSCollectionAbsolutePathFromTestProperties(
 						testingProperties, IRODS_TEST_SUBDIR_PATH + '/'
-								+ testTargetColl + "/" + testFileName);
+						+ testTargetColl + "/" + testFileName);
 		File localFile = new File(localFileName);
 
 		// now put the file
@@ -244,6 +253,8 @@ public class IrodsFileResourceTest {
 
 		IrodsFileSystemResourceFactory factory = new IrodsFileSystemResourceFactory(
 				manager);
+		LockManager lockManager = Mockito.mock(LockManager.class);
+		factory.setLockManager(lockManager);
 
 		factory.setWebDavConfig(config);
 
@@ -277,7 +288,7 @@ public class IrodsFileResourceTest {
 		String targetIrodsFile = testingPropertiesHelper
 				.buildIRODSCollectionAbsolutePathFromTestProperties(
 						testingProperties, IRODS_TEST_SUBDIR_PATH + '/'
-								+ testFileName);
+						+ testFileName);
 		File localFile = new File(localFileName);
 
 		// now put the file
@@ -296,6 +307,8 @@ public class IrodsFileResourceTest {
 
 		IrodsFileSystemResourceFactory factory = new IrodsFileSystemResourceFactory(
 				manager);
+		LockManager lockManager = Mockito.mock(LockManager.class);
+		factory.setLockManager(lockManager);
 
 		WebDavConfig config = new WebDavConfig();
 		factory.setWebDavConfig(config);
@@ -324,16 +337,16 @@ public class IrodsFileResourceTest {
 		String targetIrodsColl = testingPropertiesHelper
 				.buildIRODSCollectionAbsolutePathFromTestProperties(
 						testingProperties, IRODS_TEST_SUBDIR_PATH + '/'
-								+ testTargetColl);
+						+ testTargetColl);
 
 		String targetIrodsFile = testingPropertiesHelper
 				.buildIRODSCollectionAbsolutePathFromTestProperties(
 						testingProperties, IRODS_TEST_SUBDIR_PATH + '/'
-								+ testFileName);
+						+ testFileName);
 		String targetIrodsFileMoveTo = testingPropertiesHelper
 				.buildIRODSCollectionAbsolutePathFromTestProperties(
 						testingProperties, IRODS_TEST_SUBDIR_PATH + '/'
-								+ testTargetColl + "/" + testFileName);
+						+ testTargetColl + "/" + testFileName);
 		File localFile = new File(localFileName);
 
 		// now put the file
@@ -372,6 +385,8 @@ public class IrodsFileResourceTest {
 
 		IrodsFileSystemResourceFactory factory = new IrodsFileSystemResourceFactory(
 				manager);
+		LockManager lockManager = Mockito.mock(LockManager.class);
+		factory.setLockManager(lockManager);
 
 		factory.setWebDavConfig(config);
 

--- a/src/test/java/org/irods/jargon/webdav/resource/IrodsFileSystemResourceFactoryTest.java
+++ b/src/test/java/org/irods/jargon/webdav/resource/IrodsFileSystemResourceFactoryTest.java
@@ -3,6 +3,8 @@
  */
 package org.irods.jargon.webdav.resource;
 
+import io.milton.http.LockManager;
+
 import java.util.Properties;
 
 import junit.framework.Assert;
@@ -20,6 +22,7 @@ import org.irods.jargon.webdav.config.WebDavConfig;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 /**
  * @author Mike Conway - DICE
@@ -84,6 +87,8 @@ public class IrodsFileSystemResourceFactoryTest {
 
 		factory.getSecurityManager().authenticate(irodsAccount.getUserName(),
 				irodsAccount.getPassword());
+		LockManager lockManager = Mockito.mock(LockManager.class);
+		factory.setLockManager(lockManager);
 
 		IRODSFile pathFile = factory.resolvePath(myPath);
 		Assert.assertEquals("should have root", myPath,
@@ -127,6 +132,8 @@ public class IrodsFileSystemResourceFactoryTest {
 
 		IrodsFileSystemResourceFactory factory = new IrodsFileSystemResourceFactory(
 				manager);
+		LockManager lockManager = Mockito.mock(LockManager.class);
+		factory.setLockManager(lockManager);
 
 		factory.setWebDavConfig(config);
 
@@ -165,6 +172,8 @@ public class IrodsFileSystemResourceFactoryTest {
 				manager);
 
 		factory.setWebDavConfig(config);
+		LockManager lockManager = Mockito.mock(LockManager.class);
+		factory.setLockManager(lockManager);
 
 		factory.getSecurityManager().authenticate(irodsAccount.getUserName(),
 				irodsAccount.getPassword());
@@ -215,6 +224,8 @@ public class IrodsFileSystemResourceFactoryTest {
 				manager);
 
 		factory.setWebDavConfig(config);
+		LockManager lockManager = Mockito.mock(LockManager.class);
+		factory.setLockManager(lockManager);
 
 		factory.getSecurityManager().authenticate(irodsAccount.getUserName(),
 				irodsAccount.getPassword());
@@ -264,6 +275,8 @@ public class IrodsFileSystemResourceFactoryTest {
 				manager);
 
 		factory.setWebDavConfig(config);
+		LockManager lockManager = Mockito.mock(LockManager.class);
+		factory.setLockManager(lockManager);
 
 		factory.getSecurityManager().authenticate(irodsAccount.getUserName(),
 				irodsAccount.getPassword());
@@ -315,6 +328,8 @@ public class IrodsFileSystemResourceFactoryTest {
 				manager);
 
 		factory.setWebDavConfig(config);
+		LockManager lockManager = Mockito.mock(LockManager.class);
+		factory.setLockManager(lockManager);
 
 		factory.getSecurityManager().authenticate(irodsAccount.getUserName(),
 				irodsAccount.getPassword());

--- a/src/test/java/org/irods/jargon/webdav/unittest/AllTests.java
+++ b/src/test/java/org/irods/jargon/webdav/unittest/AllTests.java
@@ -1,5 +1,6 @@
 package org.irods.jargon.webdav.unittest;
 
+import org.irods.jargon.webdav.resource.FileContentServiceTest;
 import org.irods.jargon.webdav.resource.IrodsDirectoryResourceTest;
 import org.irods.jargon.webdav.resource.IrodsFileResourceTest;
 import org.irods.jargon.webdav.resource.IrodsFileSystemResourceFactoryTest;
@@ -9,7 +10,7 @@ import org.junit.runners.Suite.SuiteClasses;
 
 @RunWith(Suite.class)
 @SuiteClasses({ IrodsFileResourceTest.class, IrodsDirectoryResourceTest.class,
-		IrodsFileSystemResourceFactoryTest.class })
+	IrodsFileSystemResourceFactoryTest.class, FileContentServiceTest.class })
 public class AllTests {
 
 }

--- a/src/test/resources/miltonContext.xml
+++ b/src/test/resources/miltonContext.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:context="http://www.springframework.org/schema/context"
+	xmlns:beans="http://www.springframework.org/schema/beans"
+	
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/context/spring-context-3.0.xsd http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+
+	<context:property-placeholder  location="classpath:test-irods-webdav.properties" />
+	<beans:import resource="classpath:milton-beans.xml" />
+	
+</beans>


### PR DESCRIPTION
Hi,

Just took the liberty of making a pull request.  This is an implementation to cache IRODSAccount credential in the irons-webdav framework, using [Apache Commons JCS](https://commons.apache.org/proper/commons-jcs/).

The validity of the cache is configurable via the file: src/main/resources/cache.ccf

Comments and suggestions are welcomed.

Cheers, Hong
